### PR TITLE
Actually run the `when` callback

### DIFF
--- a/test.js
+++ b/test.js
@@ -219,6 +219,32 @@ describe('liferaft', function () {
       raft.join(function () { throw new Error('You sir, msg the wrong node'); });
       raft.message(node.address, raft.packet('address'));
     });
+
+    it('runs the `when` callback with no errors', function (next) {
+      var node = raft.join(function (data, callback) {
+        callback(null, 'foo');
+      });
+      node.address = 'addr';
+
+      raft.message(Raft.FOLLOWER, raft.packet('foo'), function (err, data) {
+        assume(err).equals(null);
+        assume(data).deep.equals({ addr: 'foo' });
+        next();
+      });
+    });
+
+    it('runs the `when` callback with no errors', function (next) {
+      var node = raft.join(function (data, callback) {
+        callback('bar');
+      });
+      node.address = 'addr';
+
+      raft.message(Raft.FOLLOWER, raft.packet('foo'), function (err, data) {
+        assume(err).deep.equals({ addr: 'bar' });
+        assume(data).deep.equals({});
+        next();
+      });
+    });
   });
 
   describe('#timeout', function () {


### PR DESCRIPTION
Previously, the .message when callback was never actually fired anywhere.

As far as the parameters go, what I've done is made is so:
 * The "data" is an object where the keys are node addresses and the values are that node's reply;
 * The "error" is null (if there were no errors) or a similar object with the values being the appropriate errors.