### PR TITLE
Fix leave removing more than one node

### DIFF
--- a/index.js
+++ b/index.js
@@ -834,9 +834,9 @@ Raft.prototype.leave = function leave(address) {
   }
 
   if (~index && node) {
-    if (node.end) node.end();
-
     raft.nodes.splice(index, 1);
+
+    if (node.end) node.end();
     raft.emit('leave', node);
   }
 

--- a/test.js
+++ b/test.js
@@ -1027,4 +1027,17 @@ describe('liferaft', function () {
       });
     });
   });
+  describe('bugs', function () {
+    it('correctly deletes nodes from the list on leave', function () {
+      raft.join('1');
+      raft.join('2');
+      raft.join('3');
+
+      assume(raft.nodes.length).equals(3);
+
+      raft.leave('2');
+
+      assume(raft.nodes.length).equals(2);
+    });
+  });
 });


### PR DESCRIPTION
When leaving a node (using an outside event or whatever to see if the node had died) liferaft would run [end](https://github.com/unshiftio/liferaft/blob/master/index.js#L837) on the node you're leaving.

This would in turn emit the `end` event, which then would be caught in [this once listener](https://github.com/unshiftio/liferaft/blob/master/index.js#L806), resulting in it running leave again.

The second time around running leave, the `end` call will just break since the node is already in the `STOPPED` state. After this the splice will happen twice on the same index (one from the original call, and one from the event listener's call), effectively removing 2 nodes from the list (if there are more after the index we're deleting)

I added a failing test case and then fixed the issue.

Before fix:
```
  liferaft
    bugs
      1) correctly deletes nodes from the list on leave

  0 passing (19ms)
  1 failing

  1) liferaft bugs correctly deletes nodes from the list on leave:
     Unknown assertation failure occured, assumed `1` to equal (===) `2`
      1040.       assume(raft.nodes.length).equals(2);
```

After fix:
```
  liferaft
    bugs
      ✓ correctly deletes nodes from the list on leave
  1 passing (15ms)
```