### PR TITLE
Add Log Replication

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -1,0 +1,157 @@
+{
+  "name": "example",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "amp": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/amp/-/amp-0.3.1.tgz",
+      "integrity": "sha1-at+NWKdPNh6CwfqNOJwHnhOfxH0="
+    },
+    "amp-message": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/amp-message/-/amp-message-0.1.2.tgz",
+      "integrity": "sha1-p48cmJlQh602GSpBKY5NtJ49/EU=",
+      "requires": {
+        "amp": "0.3.1"
+      }
+    },
+    "argh": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/argh/-/argh-0.1.4.tgz",
+      "integrity": "sha1-PrTWEpc/xrbcbvM49W91nyrFw6Y="
+    },
+    "axon": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/axon/-/axon-2.0.3.tgz",
+      "integrity": "sha1-kLyaMeMKz9rv95Wtp6uiLFEHlpI=",
+      "requires": {
+        "amp": "0.3.1",
+        "amp-message": "0.1.2",
+        "configurable": "0.0.1",
+        "debug": "3.1.0",
+        "escape-regexp": "0.0.1"
+      }
+    },
+    "bindings": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
+    },
+    "color": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-0.8.0.tgz",
+      "integrity": "sha1-iQwHw/1OZJU3Y4kRz2keVFi2/KU=",
+      "requires": {
+        "color-convert": "0.5.3",
+        "color-string": "0.3.0"
+      }
+    },
+    "color-convert": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+      "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+      "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "colornames": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz",
+      "integrity": "sha1-2BH9bIT1kClJmorEQ2ICk1uSvjE="
+    },
+    "colorspace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.0.1.tgz",
+      "integrity": "sha1-yZx5btMRKLmHalLh7l7gOkpxl0k=",
+      "requires": {
+        "color": "0.8.0",
+        "text-hex": "0.0.0"
+      }
+    },
+    "configurable": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/configurable/-/configurable-0.0.1.tgz",
+      "integrity": "sha1-R9dbcntRtOuEwdra/j+CQDE4M7E="
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "diagnostics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.0.tgz",
+      "integrity": "sha1-4QkJALSVI+hSe+IPCBJ1IF8q42o=",
+      "requires": {
+        "colorspace": "1.0.1",
+        "enabled": "1.0.2",
+        "kuler": "0.0.0"
+      }
+    },
+    "enabled": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
+      "requires": {
+        "env-variable": "0.0.3"
+      }
+    },
+    "env-variable": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.3.tgz",
+      "integrity": "sha1-uGwWQb5WECZ9UG8YBx6nbXBwl8s="
+    },
+    "escape-regexp": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/escape-regexp/-/escape-regexp-0.0.1.tgz",
+      "integrity": "sha1-9EvaEtRbvfnLf4Yu5+SCez3TIlQ="
+    },
+    "kuler": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz",
+      "integrity": "sha1-tmu0a5NOVQ9Z2BiEjgq7pPf1VTw=",
+      "requires": {
+        "colornames": "0.0.2"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "nan": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
+      "integrity": "sha1-+zxZ1F/k7/4hXwuJD4rfbrMtIjI="
+    },
+    "nanomsg": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/nanomsg/-/nanomsg-4.0.1.tgz",
+      "integrity": "sha512-Vr0DIJ2hitSLphyXNrS8+7fMiAUBbdyP7R5QO8lcl96bu/YYRuAHRgjNE+PZ9gr2M/R2N5W3xpSUYDLOxwpJAQ==",
+      "requires": {
+        "bindings": "1.2.1",
+        "nan": "2.4.0"
+      }
+    },
+    "text-hex": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz",
+      "integrity": "sha1-V4+8haapJjbkLdF7QdAhjM6esrM="
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -630,6 +630,20 @@
         "to-fast-properties": "2.0.0"
       }
     },
+    "abstract-leveldown": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+      "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+      "dev": true,
+      "requires": {
+        "xtend": "4.0.1"
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
     "ansi-styles": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
@@ -648,6 +662,20 @@
       "requires": {
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
+      }
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "requires": {
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.3"
       }
     },
     "arr-diff": {
@@ -709,6 +737,19 @@
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true,
       "optional": true
+    },
+    "bindings": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+    },
+    "bl": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+      "requires": {
+        "readable-stream": "2.3.3"
+      }
     },
     "brace-expansion": {
       "version": "1.1.8",
@@ -781,6 +822,16 @@
         "path-is-absolute": "1.0.1",
         "readdirp": "2.1.0"
       }
+    },
+    "chownr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "color": {
       "version": "0.8.0",
@@ -869,6 +920,11 @@
         "typedarray": "0.0.6"
       }
     },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
     "convert-source-map": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
@@ -884,8 +940,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
       "version": "5.1.0",
@@ -907,6 +962,14 @@
         "ms": "2.0.0"
       }
     },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "requires": {
+        "mimic-response": "1.0.0"
+      }
+    },
     "deep-eql": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
@@ -915,6 +978,39 @@
       "requires": {
         "type-detect": "0.1.1"
       }
+    },
+    "deep-extend": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+    },
+    "deferred-leveldown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-2.0.3.tgz",
+      "integrity": "sha512-8c2Hv+vIwKNc7qqy4zE3t5DIsln+FQnudcyjLYstHwLFg7XnXZT/H8gQb8lj6xi8xqGM0Bz633ZWcCkonycBTA==",
+      "requires": {
+        "abstract-leveldown": "3.0.0"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-3.0.0.tgz",
+          "integrity": "sha512-KUWx9UWGQD12zsmLNj64/pndaz4iJh/Pj7nopgkfDG6RlCcbMZvT6+9l7dchK4idog2Is8VdC/PvNbFuFmalIQ==",
+          "requires": {
+            "xtend": "4.0.1"
+          }
+        }
+      }
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "diagnostics": {
       "version": "1.1.0",
@@ -953,11 +1049,47 @@
         "env-variable": "0.0.3"
       }
     },
+    "encoding-down": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-3.0.1.tgz",
+      "integrity": "sha512-uvx+39YNqiPLqhXAvOSGBVy/oYBh4p2ShwG9YFCipwgfOhnVIOxuOPE3R9dEGM44bn0VHIrC3ojXq6lNf2ulwg==",
+      "requires": {
+        "abstract-leveldown": "3.0.0",
+        "level-codec": "8.0.0",
+        "level-errors": "1.1.2"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-3.0.0.tgz",
+          "integrity": "sha512-KUWx9UWGQD12zsmLNj64/pndaz4iJh/Pj7nopgkfDG6RlCcbMZvT6+9l7dchK4idog2Is8VdC/PvNbFuFmalIQ==",
+          "requires": {
+            "xtend": "4.0.1"
+          }
+        }
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "requires": {
+        "once": "1.4.0"
+      }
+    },
     "env-variable": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.3.tgz",
       "integrity": "sha1-uGwWQb5WECZ9UG8YBx6nbXBwl8s=",
       "dev": true
+    },
+    "errno": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
+      "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
+      "requires": {
+        "prr": "1.0.1"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -994,6 +1126,11 @@
         "fill-range": "2.2.3"
       }
     },
+    "expand-template": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
+      "integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ=="
+    },
     "extendible": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/extendible/-/extendible-0.1.1.tgz",
@@ -1007,6 +1144,11 @@
       "requires": {
         "is-extglob": "1.0.0"
       }
+    },
+    "fast-future": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz",
+      "integrity": "sha1-hDWpqqAteSSNF9cE52JZMB2ZKAo="
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -1984,6 +2126,32 @@
         }
       }
     },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.2"
+      }
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -2041,6 +2209,11 @@
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
       "dev": true
     },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -2071,8 +2244,12 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "invariant": {
       "version": "2.2.2",
@@ -2126,6 +2303,14 @@
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
       "dev": true
     },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
     "is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
@@ -2165,8 +2350,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -2219,6 +2403,62 @@
         "colornames": "0.0.2"
       }
     },
+    "level-codec": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-8.0.0.tgz",
+      "integrity": "sha512-gNZlo1HRHz0BWxzGCyNf7xntAs2HKOPvvRBWtXsoDvEX4vMYnSTBS6ZnxoaiX7nhxSBPpegRa8CQ/hnfGBKk3Q=="
+    },
+    "level-errors": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.1.2.tgz",
+      "integrity": "sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==",
+      "requires": {
+        "errno": "0.1.6"
+      }
+    },
+    "level-iterator-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.0.tgz",
+      "integrity": "sha512-TWOYw8HR5mhj6xwoVLo0yu26RPL6v28KgvhK1kY1CJf9LyL+rJXjx99zhORTYhN9ysOBIH+iaxAiqRteA+C1/g==",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
+      }
+    },
+    "leveldown": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-3.0.0.tgz",
+      "integrity": "sha512-CA2mRUDTgVscTDOCvHSgYvksqj1VW7g3ss2idWfITSB7l201ahQJ81cwLTupW76idbjpx7zmmmpdttYnnHWWtA==",
+      "requires": {
+        "abstract-leveldown": "4.0.0",
+        "bindings": "1.3.0",
+        "fast-future": "1.0.2",
+        "nan": "2.8.0",
+        "prebuild-install": "2.5.1"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.0.tgz",
+          "integrity": "sha512-92iwnyHeclqJor8B1n32+qX9AGrLPTP9w9Wc4TI3pJmld2DM600mH5viHex3FPSE2BRIkHBM6dRefimlQt6lPw==",
+          "requires": {
+            "xtend": "4.0.1"
+          }
+        }
+      }
+    },
+    "levelup": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-2.0.1.tgz",
+      "integrity": "sha1-PckbPmMtN8nlRiOchkEYsATJ+GA=",
+      "requires": {
+        "deferred-leveldown": "2.0.3",
+        "level-errors": "1.1.2",
+        "level-iterator-stream": "2.0.0",
+        "xtend": "4.0.1"
+      }
+    },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -2254,6 +2494,12 @@
         "yallist": "2.1.2"
       }
     },
+    "ltgt": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.0.tgz",
+      "integrity": "sha1-tlul/LNJopkkyOMz98alVi8uSEI=",
+      "dev": true
+    },
     "make-dir": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
@@ -2261,6 +2507,20 @@
       "dev": true,
       "requires": {
         "pify": "3.0.0"
+      }
+    },
+    "memdown": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
+      "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
+      "dev": true,
+      "requires": {
+        "abstract-leveldown": "2.7.2",
+        "functional-red-black-tree": "1.0.1",
+        "immediate": "3.2.3",
+        "inherits": "2.0.3",
+        "ltgt": "2.2.0",
+        "safe-buffer": "5.1.1"
       }
     },
     "micromatch": {
@@ -2289,6 +2549,11 @@
       "resolved": "https://registry.npmjs.org/millisecond/-/millisecond-0.1.2.tgz",
       "integrity": "sha1-bMWtOGJByrjniv+WT4cCjuyS2sU="
     },
+    "mimic-response": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
+      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -2301,22 +2566,20 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
     },
     "mocha": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
-      "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.0.tgz",
+      "integrity": "sha512-ukB2dF+u4aeJjc6IGtPNnJXfeby5d4ZqySlIBT0OEyva/DrMjVm5HkQxKnHDLKEfEQBsEnwTg9HHhtPHJdTd8w==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -2362,15 +2625,26 @@
     "nan": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
-      "dev": true,
-      "optional": true
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
+    },
+    "node-abi": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.2.0.tgz",
+      "integrity": "sha512-FqVC0WNNL8fQWQK3GYTESfwZXZKDbSIiEEIvufq7HV6Lj0IDDZRVa4CU/KTA0JVlqY9eTDSuPiC8FS9UfGVuzA==",
+      "requires": {
+        "semver": "5.5.0"
+      }
     },
     "node-modules-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
       "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
       "dev": true
+    },
+    "noop-logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
     },
     "normalize-path": {
       "version": "2.1.1",
@@ -2380,6 +2654,22 @@
       "requires": {
         "remove-trailing-separator": "1.1.0"
       }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "1.1.4",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nyc": {
       "version": "11.4.1",
@@ -3975,6 +4265,11 @@
         }
       }
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
     "object-inspect": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.0.2.tgz",
@@ -3995,7 +4290,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -4004,6 +4298,11 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
       "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-shim": {
       "version": "0.1.3",
@@ -4117,6 +4416,35 @@
         "which": "1.2.14"
       }
     },
+    "prebuild-install": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.1.tgz",
+      "integrity": "sha512-3DX9L6pzwc1m1ksMkW3Ky2WLgPQUBiySOfXVl3WZyAeJSyJb4wtoH9OmeRGcubAWsMlLiL8BTHbwfm/jPQE9Ag==",
+      "requires": {
+        "detect-libc": "1.0.3",
+        "expand-template": "1.1.0",
+        "github-from-package": "0.0.0",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "node-abi": "2.2.0",
+        "noop-logger": "0.1.1",
+        "npmlog": "4.1.2",
+        "os-homedir": "1.0.2",
+        "pump": "2.0.1",
+        "rc": "1.2.5",
+        "simple-get": "2.7.0",
+        "tar-fs": "1.16.0",
+        "tunnel-agent": "0.6.0",
+        "which-pm-runs": "1.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
@@ -4132,8 +4460,12 @@
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "pruddy-error": {
       "version": "1.0.2",
@@ -4146,6 +4478,15 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
+    },
+    "pump": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "requires": {
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
+      }
     },
     "randomatic": {
       "version": "1.1.7",
@@ -4188,11 +4529,28 @@
         }
       }
     },
+    "rc": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.5.tgz",
+      "integrity": "sha1-J1zWh/bjs2zHVrqibf7oCnkDAf0=",
+      "requires": {
+        "deep-extend": "0.4.2",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -4316,14 +4674,17 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-      "dev": true
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-immediate-shim": {
       "version": "1.0.1",
@@ -4346,6 +4707,26 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "simple-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+    },
+    "simple-get": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.7.0.tgz",
+      "integrity": "sha512-RkE9rGPHcxYZ/baYmgJtOSM63vH0Vyq+ma5TijBcLla41SWlh8t6XYIGMR/oeZcmr+/G8k+zrClkkVrtnQ0esg==",
+      "requires": {
+        "decompress-response": "3.3.0",
+        "once": "1.4.0",
+        "simple-concat": "1.0.0"
+      }
     },
     "slash": {
       "version": "1.0.0",
@@ -4378,14 +4759,36 @@
         "os-shim": "0.1.3"
       }
     },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "supports-color": {
       "version": "4.5.0",
@@ -4394,6 +4797,39 @@
       "dev": true,
       "requires": {
         "has-flag": "2.0.0"
+      }
+    },
+    "tar-fs": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
+      "integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
+      "requires": {
+        "chownr": "1.0.1",
+        "mkdirp": "0.5.1",
+        "pump": "1.0.3",
+        "tar-stream": "1.5.5"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+          "requires": {
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
+          }
+        }
+      }
+    },
+    "tar-stream": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+      "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+      "requires": {
+        "bl": "1.2.1",
+        "end-of-stream": "1.4.1",
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
       }
     },
     "text-hex": {
@@ -4421,6 +4857,14 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "type-detect": {
       "version": "0.1.1",
@@ -4465,8 +4909,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "which": {
       "version": "1.2.14",
@@ -4477,11 +4920,28 @@
         "isexe": "2.0.0"
       }
     },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
+    },
+    "wide-align": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "requires": {
+        "string-width": "1.0.2"
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "yallist": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "browser": "./lib/",
   "scripts": {
-    "test": "mocha test.js",
+    "test": "mocha test/**.js",
     "test-travis": "nyc --reporter=html --reporter=text npm test",
     "prepublish": "npm run build",
     "build": "babel ./index.js -d ./lib"
@@ -27,22 +27,26 @@
   "homepage": "https://github.com/unshiftio/liferaft",
   "dependencies": {
     "emits": "3.0.x",
+    "encoding-down": "^3.0.1",
     "eventemitter3": "2.0.x",
     "extendible": "0.1.x",
     "immediate": "3.2.x",
+    "leveldown": "^3.0.0",
+    "levelup": "^2.0.1",
     "millisecond": "0.1.x",
     "modification": "1.0.x",
     "one-time": "0.0.x",
     "tick-tock": "1.0.x"
   },
   "devDependencies": {
+    "@babel/cli": "^7.0.0-beta.38",
     "@babel/core": "^7.0.0-beta.38",
     "@babel/preset-env": "^7.0.0-beta.38",
     "@babel/register": "^7.0.0-beta.38",
-    "@babel/cli": "^7.0.0-beta.38",
     "assume": "1.5.x",
     "diagnostics": "1.1.x",
-    "mocha": "4.0.x",
+    "memdown": "^1.4.1",
+    "mocha": "5.0.x",
     "nyc": "^11.3.0",
     "pre-commit": "1.2.x"
   },

--- a/test/cluster.js
+++ b/test/cluster.js
@@ -1,0 +1,128 @@
+const assume = require('assume');
+const Raft = require('../');
+const Log = require('../log');
+
+//
+// Batch of tests which tests the clustering capabilities of liferaft as
+// everything works different when you start working with massive clusters.
+//
+
+/* istanbul ignore next */
+describe('cluster', function () {
+  var port = 8088
+    , net = require('net')
+    , debug = require('diagnostics')('cluster');
+
+  class Paddle extends Raft {
+    /**
+     * Initialize the server so we can receive connections.
+     *
+     * @param {Object} options Received optiosn when constructing the client.
+     * @api private
+     */
+    initialize(options) {
+      var raft = this;
+
+      var server = net.createServer(function incoming(socket) {
+        socket.on('data', function (buff) {
+          var data = JSON.parse(buff.toString());
+
+          debug(raft.address +':packet#data', data);
+          raft.emit('data', data, function reply(data) {
+            debug(raft.address +':packet#reply', data);
+            socket.write(JSON.stringify(data));
+            socket.end();
+          });
+        });
+      }).listen(this.address);
+
+      this.once('end', function end() {
+        server.close();
+      });
+    }
+
+    /**
+     * Write to the connection.
+     *
+     * @param {Object} packet Data to be transfered.
+     * @param {Function} fn Completion callback.
+     * @api public
+     */
+    write(packet, fn) {
+      var socket = net.connect(this.address)
+        , raft = this;
+
+      debug(raft.address +':packet#write', packet);
+      socket.on('error', fn);
+      socket.on('data', function (buff) {
+        var data;
+
+        try { data = JSON.parse(buff.toString()); }
+        catch (e) { return fn(e); }
+
+        debug(raft.address +':packet#callback', packet);
+        fn(undefined, data);
+      });
+
+      socket.setNoDelay(true);
+      socket.write(JSON.stringify(packet));
+    }
+  }
+
+  it.skip('reaches consensus about leader election', function (next) {
+    var ports = [port++, port++, port++, port++]
+      , nodes = []
+      , node
+      , i
+      , j;
+
+    for (i = 0; i < ports.length; i++) {
+      node = new Paddle(ports[i]);
+      nodes.push(node);
+
+      for (j = 0; j < ports.length; j++) {
+        if (ports[j] === ports[i]) continue;
+
+        node.join(ports[j]);
+      }
+    }
+
+    for (i = 0; i < nodes.length; i++) {
+      if (nodes[i] === node) continue;
+
+      nodes[i].once('state change', function (to, from) {
+        throw new Error('I should not change state, im a follower');
+      });
+
+      nodes[i].on('leader change', function (to, from) {
+        assume(to).equals(node.address);
+      });
+    }
+
+    //
+    // Force a node in to a candidate role to ensure that this node will be
+    // promoted as leader as it's the first to be alive.
+    //
+    node.promote();
+    node.once('state change', function changed(state) {
+      assume(state).equals(Paddle.LEADER);
+
+      //
+      // Check if every node is in sync
+      //
+      for (i = 0; i < nodes.length; i++) {
+        if (node === nodes[i]) continue;
+
+        assume(nodes[i].leader).equals(node.address);
+        assume(nodes[i].state).equals(Raft.FOLLOWER);
+        assume(nodes[i].term).equals(node.term);
+      }
+
+      for (i = 0; i < ports.length; i++) {
+        nodes[i].end();
+      }
+
+      next();
+    });
+  });
+});

--- a/test/log.js
+++ b/test/log.js
@@ -1,0 +1,336 @@
+const assume = require('assume');
+const Log = require('../log');
+const debug = require('diagnostics')('cluster');
+
+describe('Leveldown Log', () => {
+  let log;
+
+  beforeEach(() => {
+    log = new Log(
+      {term: 1, address: 8000},
+      {adapter: require('memdown')}
+    );
+
+  });
+
+  it('saves and gets', async () => {
+    const command = {'first': 'command'};
+    await log.put({
+      index: 1,
+      term: 1,
+      command
+    });
+
+    const entry = await log.get(1);
+
+    assume(entry.index).equals(1);
+    assume(entry.term).equals(1);
+    assume(entry.command).deep.equals(command);
+  });
+
+  it('get returns error for missing', () => {
+    return log.get(10)
+    .catch(err => {
+      assume(err.notFound).true;
+    });
+  });
+
+  it('#has returns true for item', async () => {
+    const command = {'first': 'command'};
+    await log.put({
+      index: 1,
+      term: 1,
+      command
+    });
+
+    const resp = log.has({index: 1, term: 1});
+    assume(resp).true;
+
+  });
+
+  it('#has returns false for no item', async () => {
+    const resp = log.has({index: 1, term: 1});
+    assume(resp).false;
+  });
+
+  it('#getLastEntry returns last entry', async () => {
+    const command1 = {'first': 'command'};
+    const command2 = {'second': 'command'};
+    await log.put({
+      index: 1,
+      term: 1,
+      command: command1
+    });
+
+    await log.put({
+      index: 2,
+      term: 1,
+      command: command2
+    });
+
+    const entry = await log.getLastEntry();
+    assume(entry.index).equals(2);
+    assume(entry.command).deep.equals(command2);
+  });
+
+  it('#getLastEntry returns 0 index for empty', async () => {
+    const entry = await log.getLastEntry();
+    assume(entry.index).equals(0);
+  });
+
+  it('#getLastInfo returns last entry', async () => {
+    const command1 = {'first': 'command'};
+    const command2 = {'second': 'command'};
+    await log.put({
+      index: 1,
+      term: 1,
+      command: command1
+    });
+
+    await log.put({
+      index: 2,
+      term: 2,
+      command: command2
+    });
+
+    const entry = await log.getLastInfo();
+    assume(entry.index).equals(2);
+    assume(entry.committedIndex).equals(0);
+    assume(entry.term).equals(2);
+  });
+
+  it('#getLastInfo returns 0 index for empty', async () => {
+    const entry = await log.getLastInfo();
+    assume(entry.index).equals(0);
+  });
+
+  it('#commit commits entry', async () => {
+    const command = {'first': 'command'};
+    await log.put({
+      index: 1,
+      term: 1,
+      command: command,
+      committed: false
+    });
+
+    await log.commit(1);
+
+    const entry = log.get(1);
+    assume(entry.committed).true;
+  });
+
+  it('#getUncommittedEntriesUpToIndex returns uncommitted entries', async () => {
+    const command1 = {'first': 'command'};
+    const command2 = {'second': 'command'};
+    const command3 = {'third': 'command'};
+
+    await log.put({
+      index: 1,
+      term: 1,
+      command: command1,
+      committed: true
+    });
+
+    await log.put({
+      index: 2,
+      term: 2,
+      command: command2,
+      committed: false
+    });
+
+    await log.put({
+      index: 3,
+      term: 2,
+      command: command3,
+      committed: false
+    });
+
+    const entries = await log.getUncommittedEntriesUpToIndex(3);
+    assume(entries.length).equals(2);
+    assume(entries[0].command).deep.equals(command2);
+    assume(entries[1].command).deep.equals(command3);
+  });
+
+  it('#commandAck saves vote for entry', async () => {
+    const command = {'first': 'command'};
+
+    await log.put({
+      index: 1,
+      term: 1,
+      command,
+      committed: true,
+      responses: []
+    });
+
+    await log.commandAck(1, 8888);
+
+    const entry = await log.get(1);
+    assume(entry.responses.length).equal(1);
+    assume(entry.responses[0].address).equal(8888);
+    assume(entry.responses[0].ack).equal(true);
+  });
+
+  it('#getEntryBefore returns 0 index empty', async () => {
+    const command1 = {'first': 'command'};
+    await log.put({
+      index: 1,
+      term: 1,
+      command: command1
+    });
+
+    const entry = await log.getEntryBefore({index: 1, term: 1});
+    assume(entry.index).equals(0);
+  });
+
+  it('#getEntryBefore returns 0 index if none before', async () => {
+    const command1 = {'first': 'command'};
+    await log.put({
+      index: 1,
+      term: 1,
+      command: command1
+    });
+
+    const entry = await log.getEntryBefore({index: 1, term: 1});
+    assume(entry.index).equals(0);
+  });
+
+  it('#getEntryBefore returns previous entry', async () => {
+    const command1 = {'first': 'command'};
+    const command2 = {'second': 'command'};
+    const command3 = {'third': 'command'};
+    await log.put({
+      index: 1,
+      term: 1,
+      command: command1
+    });
+
+    await log.put({
+      index: 2,
+      term: 1,
+      command: command2
+    });
+
+    await log.put({
+      index: 3,
+      term: 1,
+      command: command3
+    });
+
+    const entry = await log.getEntryBefore({index: 3, term: 1});
+    assume(entry.index).equals(2);
+    assume(entry.command).deep.equals(command2);
+  });
+
+  it('#getEntryInfo returns previous entry', async () => {
+    const command1 = {'first': 'command'};
+    const command2 = {'second': 'command'};
+    const command3 = {'third': 'command'};
+    await log.put({
+      index: 1,
+      term: 1,
+      command: command1
+    });
+
+    await log.put({
+      index: 2,
+      term: 1,
+      command: command2
+    });
+
+    await log.put({
+      index: 3,
+      term: 1,
+      command: command3
+    });
+
+    const entry = await log.getEntryInfoBefore({index: 3, term: 1});
+    assume(entry.index).equals(2);
+    assume(entry.committedIndex).deep.equals(0);
+  });
+
+  it('#getEntriesAfter returns correct entries', async () => {
+    const command1 = {'first': 'command'};
+    const command2 = {'second': 'command'};
+    const command3 = {'third': 'command'};
+    await log.put({
+      index: 1,
+      term: 1,
+      command: command1
+    });
+
+    await log.put({
+      index: 2,
+      term: 1,
+      command: command2
+    });
+
+    await log.put({
+      index: 3,
+      term: 1,
+      command: command3
+    });
+
+    const entries = await log.getEntriesAfter(1);
+    assume(entries.length).equals(2);
+    assume(entries[0].index).equals(2);
+    assume(entries[1].index).equals(3);
+  });
+
+
+  it('#removeEntriesAfter removes entries after entry', async () => {
+    const command1 = {'first': 'command'};
+    const command2 = {'second': 'command'};
+    const command3 = {'third': 'command'};
+    await log.put({
+      index: 1,
+      term: 1,
+      command: command1
+    });
+
+    await log.put({
+      index: 2,
+      term: 1,
+      command: command2
+    });
+
+    await log.put({
+      index: 3,
+      term: 1,
+      command: command3
+    });
+
+    await log.removeEntriesAfter(1);
+    const entry = await log.getLastEntry();
+    assume(entry.index).equals(1);
+  });
+
+  it('#saveCommand saves commands', async () => {
+    const command = {'first': 'command'};
+    const term = 2;
+    await log.saveCommand(command, term);
+
+    const entry = await log.get(1);
+    assume(entry.term).equals(2);
+    assume(entry.committed).equals(false);
+    assume(entry.command).deep.equals(command);
+    assume(entry.responses.length).equals(1);
+    assume(entry.responses[0]).deep.equals({address: 8000, ack: true});
+  });
+
+  it('#saveCommand saves all commands', async () => {
+    const command1 = {'first': 'command'};
+    const command2 = {'second': 'command'};
+    const command3 = {'third': 'command'};
+
+    await log.saveCommand(command1, 1);
+    await log.saveCommand(command2, 1);
+    await log.saveCommand(command3, 1);
+
+    const entries = await log.getEntriesAfter(0);
+
+    assume(entries.length).equals(3);
+    assume(entries[0].command).deep.equals(command1);
+    assume(entries[1].command).deep.equals(command2);
+    assume(entries[2].command).deep.equals(command3);
+  });
+});

--- a/test/raft.js
+++ b/test/raft.js
@@ -1,0 +1,142 @@
+const assume = require('assume');
+const Raft = require('../');
+const Log = require('../log');
+
+//
+// The following set of tests asserts if we correctly follow the Raft white
+// paper and that our module does what is expected of it.
+//
+describe('Raft Consensus Algorithm', function () {
+  let raft;
+
+  beforeEach(() => {
+    raft = new Raft({
+      'heartbeat min': 4000,  // Bump timeout to ensure no false positive
+      'heartbeat max': 6000   // so we don't trigger before test timeout
+    });
+  });
+
+  afterEach(() => {
+    raft.end();
+  });
+
+  describe('election', function () {
+    describe('vote', function () {
+      it('ignores stale votes when term is out of date', function () {
+        raft.once('vote', function (packet, accepted) {
+          throw new Error('Broken');
+        });
+
+        raft.change({ term: 139 });
+        raft.emit('data', {
+          address: 'vladimir',
+          type: 'vote',
+          term: 138
+        });
+      });
+
+      it('votes on first come first serve basis', function (next) {
+        raft.once('vote', function (packet, accepted) {
+          assume(accepted).is.true();
+
+          raft.once('vote', function (packet, accepted) {
+            assume(accepted).is.false();
+            next();
+          });
+        });
+
+        raft.change({ term: 139 });
+        raft.emit('data', { address: 'vladimir', term: raft.term, type: 'vote' });
+        raft.emit('data', { address: 'anatoly', term: raft.term, type: 'vote' });
+      });
+    });
+
+    describe('voted', function () {
+      it('only increments votes when being a CANDIDATE', function () {
+        assume(raft.votes.granted).equals(0);
+        assume(raft.state).equals(Raft.FOLLOWER);
+
+        raft.emit('data', {
+          data: { granted: true },
+          term: raft.term,
+          state: Raft.FOLLOWER,
+          address: 'foobar',
+          type: 'voted'
+        });
+
+        assume(raft.votes.granted).equals(0);
+
+        //
+        // Promote our selfs to candidate.
+        //
+        raft.promote();
+        assume(raft.state).equals(Raft.CANDIDATE);
+        assume(raft.votes.granted).equals(1);
+
+        raft.emit('data', {
+          data: { granted: true },
+          term: raft.term,
+          state: Raft.FOLLOWER,
+          address: 'foobar',
+          type: 'voted'
+        });
+
+        assume(raft.votes.granted).equals(2);
+        assume(raft.state).equals(Raft.CANDIDATE);
+      });
+
+      it('only accepts granted votes', function () {
+        raft.promote();
+        assume(raft.state).equals(Raft.CANDIDATE);
+        assume(raft.votes.granted).equals(1);
+
+        raft.emit('data', {
+          data: { granted: false },
+          term: raft.term,
+          state: Raft.FOLLOWER,
+          address: 'foobar',
+          type: 'voted'
+        });
+
+        assume(raft.votes.granted).equals(1);
+        assume(raft.state).equals(Raft.CANDIDATE);
+      });
+
+      it('changes to leader when majority has voted', function (next) {
+        //
+        // Feed raft some "nodes" so it can actually reach a consensus when it
+        // received a majority of the votes.
+        //
+        raft.nodes.push(
+          { write: function () {} },
+          { write: function () {} },
+          { write: function () {} },
+          { write: function () {} },
+          { write: function () {} }
+        );
+
+        raft.promote();
+
+        raft.once('state change', function (currently, previously) {
+          assume(previously).equals(Raft.CANDIDATE);
+          assume(raft.state).equals(Raft.LEADER);
+          assume(currently).equals(Raft.LEADER);
+
+          next();
+        });
+
+        for (var i = 0; i < 4; i++) {
+          raft.emit('data', {
+            data: { granted: true },
+            term: raft.term,
+            state: Raft.FOLLOWER,
+            address: 'foobar',
+            type: 'voted'
+          });
+        }
+
+        assume(raft.state).equals(Raft.LEADER);
+      });
+    });
+  });
+});

--- a/test/replication.js
+++ b/test/replication.js
@@ -1,0 +1,393 @@
+const assume = require('assume');
+const Raft = require('../');
+const Log = require('../log');
+const net = require('net');
+const debug = require('diagnostics')('cluster');
+const port = 8088;
+
+/* istanbul ignore next */
+describe('liferaft Log Replication', () => {
+  class WoodenRaft extends Raft {
+    /**
+     * Initialize the server so we can receive connections.
+     *
+     * @param {Object} options Received optiosn when constructing the client.
+     * @api private
+     */
+     initialize(options) {
+      const raft = this;
+      this.write = this.write.bind(this);
+      const sockets = [];
+      const server = net.createServer((socket) => {
+        socket.on('data', (buff) => {
+          const data = JSON.parse(buff.toString());
+
+          debug(this.address +':packet#data', data);
+          this.emit('data', data, (data) => {
+            debug(this.address +':packet#reply', data);
+            socket.write(JSON.stringify(data));
+            socket.end();
+          });
+        });
+      }).listen(this.address);
+
+      server.on('connection', socket => {
+        sockets.push(socket);
+      });
+      raft.server = server;
+
+      this.once('end', () => {
+        sockets.forEach(s => s.destroy());
+        server.close();
+      });
+    }
+
+    /**
+     * Write to the connection.
+     *
+     * @param {Object} packet Data to be transfered.
+     * @param {Function} fn Completion callback.
+     * @api public
+     */
+    write(packet, fn) {
+      const socket = net.connect(this.address);
+      const raft = this;
+
+      debug(this.address +':packet#write', packet);
+      socket.on('error', fn);
+      socket.on('data', (buff) => {
+        let data;
+
+        try { data = JSON.parse(buff.toString()); }
+        catch (e) { return fn(e); }
+
+        debug(raft.address +':packet#callback', packet);
+        fn(undefined, data);
+      });
+
+      socket.setNoDelay(true);
+      socket.write(JSON.stringify(packet));
+    }
+  }
+
+  let node1, node2, node3;
+
+  afterEach((next) => {
+    const promises = [node3, node2, node1].map(node => {
+      if (!node) {
+        return Promise.resolve();
+      }
+
+      return new Promise((resolve) => {
+        node.once('end', () => {
+          resolve();
+        });
+        node.end();
+      });
+    });
+
+    Promise.all(promises).then((args) => {
+      node1 = node2 = node3 = false;
+      next();
+    });
+  });
+
+  it('Sends correct index with start log', async () => {
+    node1 = new WoodenRaft({address: 8111, Log, adapter: require('memdown')});
+    node2 = new WoodenRaft({address: 8112, Log, adapter: require('memdown')});
+
+    node1.join(8112);
+    node2.join(8111);
+
+    node2.on('data', (packet, write) => {
+      if (packet.type === 'append') {
+        assume(packet.last.committedIndex).equals(0);
+        assume(packet.last.index).equals(0);
+        next();
+      }
+    });
+
+    return node1.promote();
+  });
+
+  it('sends append to nodes with command', (next) => {
+    const command1 = {first: 'command'};
+    node1 = new WoodenRaft({address: 8111, Log, adapter: require('memdown')});
+    node2 = new WoodenRaft({address: 8112, Log, adapter: require('memdown')});
+    node1.join(8112);
+    node2.join(8111);
+
+    node2.on('data', (packet, write) => {
+      if (packet.type === 'append' && packet.data) {
+        assume(packet.last.index).equals(0);
+        assume(packet.last.committedIndex).equals(0);
+        assume(packet.data[0].command).deep.equals(command1);
+        //not pretty but just need a small delay otherwise it shuts down the logs
+        // and node before the command has process and causes the test to throw an exception
+        setTimeout(next, 10);
+      }
+    });
+
+    node1.once('leader', async () => {
+      await node1.command(command1);
+    });
+
+    node1.promote();
+  });
+
+  it('commits command once a quorum has been reached', (next) => {
+    const command1 = {first: 'command'};
+    node1 = new WoodenRaft({address: 8111, Log, adapter: require('memdown')});
+    node2 = new WoodenRaft({address: 8112, Log, adapter: require('memdown')});
+    node1.join(8112);
+    node2.join(8111);
+
+    node1.once('commit', (command) => {
+      assume(command).deep.equals(command1);
+      next();
+    });
+
+    node1.once('leader', async () => {
+      await node1.command(command1);
+    });
+
+    node1.promote();
+  });
+
+  it('does not commit command if same node ack', async () => {
+    const command1 = {first: 'command'};
+    node1 = new WoodenRaft({address: 8111, Log, adapter: require('memdown')});
+    node2 = new WoodenRaft({address: 8112, Log, adapter: require('memdown')});
+    node1.state = Raft.LEADER;
+    await node1.command(command1);
+
+    await node1.log.commandAck(1, 8111);
+    const entry = await node1.log.get(1);
+    assume(entry.responses.length).deep.equals(1);
+  });
+
+  it('follow commits command on next hearbeat', (next) => {
+    const command1 = {first: 'command'};
+    node1 = new WoodenRaft({address: 8111, Log, adapter: require('memdown')});
+    node2 = new WoodenRaft({address: 8112, Log, adapter: require('memdown')});
+    node1.join(8112);
+    node2.join(8111);
+
+    node1.once('commit', (command) => {
+      node2.once('commit', (command) => {
+        assume(command).deep.equals(command1);
+        next();
+      });
+    });
+
+    node1.once('leader', async () => {
+      node1.command(command1);
+    });
+
+    node1.promote();
+  });
+
+  it('commits second command correctly', (next) => {
+    const command1 = {first: 'command'};
+    const command2 = {second: 'command2'};
+    let commitCalledOnNode1 = false;
+    node1 = new WoodenRaft({address: 8111, Log, adapter: require('memdown')});
+    node2 = new WoodenRaft({address: 8112, Log, adapter: require('memdown')});
+    node1.join(8112);
+    node2.join(8111);
+
+    node1.once('commit', (command) => {
+      assume(command).deep.equals(command1);
+
+      node2.once('commit', (command) => {
+        assume(command).deep.equals(command1);
+
+        node1.once('commit', (command) => {
+          assume(command).deep.equals(command2);
+          commitCalledOnNode1 = true;
+        });
+
+        node2.once('commit', (command) => {
+          assume(command).deep.equals(command2);
+          assume(commitCalledOnNode1).be.true;
+          next();
+        });
+
+        node2.on('data', (packet, write) => {
+          if (packet.type === 'append' && packet.data) {
+            assume(packet.last.index).equals(1);
+            assume(packet.last.committedIndex).equals(1);
+            assume(packet.data[0].command).deep.equals(command2);
+          }
+        });
+
+        node1.command(command2);
+      });
+    });
+
+    node1.once('leader', () => {
+      node1.command(command1);
+    });
+    node1.promote();
+  });
+
+  it('replicates log to node', (next) => {
+    const command1 = {first: 'command'};
+    const command2 = {second: 'command2'};
+    node1 = new WoodenRaft({address: 8111, Log, adapter: require('memdown')});
+
+    // add log entries
+    node1.log.put({
+      term: node1.term,
+      index: 1,
+      committed: true,
+      responses: [{address: 8111, ack: true}, {address: 8000, ack: true}],
+      command: command1,
+    });
+
+    node1.log.put({
+      term: node1.term,
+      index: 2,
+      committed: true,
+      responses: [{address: 8111, ack: true}, {address: 8000, ack: true}],
+      command: command2,
+    });
+
+    node1.log.committedIndex = 2;
+
+    node2 = new WoodenRaft({address: 8112, Log, adapter: require('memdown')});
+    node1.join(8112);
+    node2.join(8111);
+    node1.promote();
+
+    node2.once('commit', (command) => {
+      assume(command).deep.equals(command1);
+      node2.once('commit', (command) => {
+        assume(command).deep.equals(command2);
+        next();
+      });
+    });
+  });
+
+
+  it('Replicates log to new node', (next) => {
+    const command1 = {first: 'command'};
+    const command2 = {second: 'command2'};
+    node1 = new WoodenRaft({address: 8111, Log, adapter: require('memdown')});
+    node2 = new WoodenRaft({address: 8112, Log, adapter: require('memdown')});
+    node1.join(8112);
+    node2.join(8111);
+
+    node2.once('commit', (command) => {
+      assume(command).deep.equals(command1);
+      node1.command(command2);
+
+      node2.once('commit', (command) => {
+        assume(command).deep.equals(command2);
+
+        node3 = new WoodenRaft({address: 8113, Log, adapter: require('memdown')});
+        node3.join(8111);
+        node3.join(8112);
+
+        node1.join(8113);
+        node2.join(8113);
+
+        node3.once('commit', (command) => {
+          assume(command).deep.equals(command1);
+
+          node3.once('commit', (command) => {
+            assume(command).deep.equals(command2);
+            next();
+          });
+        });
+      });
+    });
+
+    node1.once('leader', () => {
+      node1.command(command1);
+    });
+    node1.promote();
+  });
+
+  // need to look back in the log for the prev item. Add this item and
+  // remove all later ones
+  it('removes conflicted entries', (next) => {
+    const command1 = {first: 'command'};
+    const command2 = {second: 'command2'};
+    const commandWrong1 = {wrong: 'command'};
+    const commandWrong2 = {wrong: 'command2'};
+    node1 = new WoodenRaft({address: 8111, Log, adapter: require('memdown')});
+    node2 = new WoodenRaft({address: 8112, Log, adapter: require('memdown')});
+
+    // add log entries
+    node1.log.put({
+      term: 1,
+      index: 1,
+      committed: true,
+      responses: [{address: 8111, ack: true}, {address: 8000, ack: true}],
+      command: command1,
+    });
+
+    node2.log.put({
+      term: 1,
+      index: 1,
+      committed: true,
+      responses: [{address: 8111, ack: true}, {address: 8000, ack: true}],
+      command: command1,
+    });
+
+    node2.log.put({
+      term: 1,
+      index: 2,
+      committed: false,
+      responses: [{address: 8112, ack: true}],
+      command: commandWrong1,
+    });
+
+    node2.log.put({
+      term: 1,
+      index: 3,
+      committed: false,
+      responses: [{address: 8112, ack: true}],
+      command: commandWrong2,
+    });
+
+    node1.log.committedIndex = 1;
+    node2.log.committedIndex = 1;
+
+    node1.term = 2;
+    node2.term = 1;
+    node1.join(8112);
+    node2.join(8111);
+
+    node2.once('leader', () => {
+      throw new Error('should never be leader');
+    });
+
+    node1.once('leader', () => {
+      node1.command(command2);
+
+      node2.once('commit', async (command) => {
+        assume(command).deep.equals(command2);
+        const entry2 = await node2.log.getLastEntry();
+        assume(entry2.index).equal(2);
+        assume(entry2.command).deep.equal(command2);
+        assume(entry2.committed).true;
+
+        const entry1 = await node2.log.getEntryBefore(entry2);
+
+        assume(entry1.index).equal(1);
+        assume(entry1.command).deep.equal(command1);
+        assume(entry1.committed).true;
+
+        const entry0 = await node2.log.getEntryBefore(entry1);
+        assume(entry0.index).equals(0);
+
+        next();
+      });
+    });
+
+    node1.promote();
+  });
+
+});


### PR DESCRIPTION
This adds support for log replication. It uses levelup to store the log
entries. LifeRaft now has a `saveCommand` method to save a command. This
command is replicated to each node. Once the majority of nodes have
saved the entry, a `commit` event if triggered.

This is quite a big change. I've tried to limit the surface area of the changes as much as possible. Two noticeable larger changes are: I've used async/await for any async operations. I did this because it then meant I didn't have to move code around much or add in lots of callbacks. And also because async/await is just plain awesome. I've also broken up the tests into their own folder and created separate files for each one. 

This is a lot of changes, so please let me know if there is some changes or style changes I have done that you don't like and I will fix them.